### PR TITLE
feat(common)!: array type should be simple

### DIFF
--- a/kwap_common/src/lib.rs
+++ b/kwap_common/src/lib.rs
@@ -86,8 +86,8 @@ pub trait GetSize {
   /// ```
   /// use kwap_common::GetSize;
   ///
-  /// let stack_nums = tinyvec::ArrayVec<[u8; 2]>::from([0, 1]);
-  /// assert_eq!(stack_nums.max_size(), 2);
+  /// let stack_nums = tinyvec::ArrayVec::<[u8; 2]>::from([0, 1]);
+  /// assert_eq!(stack_nums.max_size(), Some(2));
   /// ```
   fn max_size(&self) -> Option<usize>;
 

--- a/kwap_common/src/lib.rs
+++ b/kwap_common/src/lib.rs
@@ -8,7 +8,7 @@
 
 extern crate alloc;
 use alloc::vec::Vec;
-use core::ops::{DerefMut, Deref};
+use core::ops::{Deref, DerefMut};
 
 /// An ordered indexable collection of some type `T`
 ///

--- a/kwap_common/src/lib.rs
+++ b/kwap_common/src/lib.rs
@@ -48,6 +48,7 @@ pub trait Array<T>:
   + IndexMut<usize>
   + GetSize
   + Reserve
+  + SortByKey<T>
   + Extend<T>
   + FromIterator<T>
   + IntoIterator<Item = T>
@@ -125,6 +126,35 @@ impl<A: tinyvec::Array> GetSize for tinyvec::ArrayVec<A> {
 
   fn max_size(&self) -> Option<usize> {
     Some(A::CAPACITY)
+  }
+}
+
+/// A collection that can be sorted
+pub trait SortByKey<T> {
+  /// Sort the collection in place using a closure
+  /// that plucks something that implements `Ord` from its elements.
+  ///
+  /// ```
+  /// use kwap_common::SortByKey;
+  ///
+  /// let mut nums = vec![2, 1, 3, 5, 4];
+  ///
+  /// SortByKey::sort_by_key(&mut nums, |n| *n);
+  ///
+  /// assert_eq!(nums, vec![1, 2, 3, 4, 5]);
+  /// ```
+  fn sort_by_key<K: Ord>(&mut self, f: impl Fn(&T) -> K);
+}
+
+impl<T> SortByKey<T> for Vec<T> {
+  fn sort_by_key<K: Ord>(&mut self, f: impl Fn(&T) -> K) {
+    self.as_mut_slice().sort_by_key(f)
+  }
+}
+
+impl<A: tinyvec::Array<Item = T>, T> SortByKey<T> for tinyvec::ArrayVec<A> {
+  fn sort_by_key<K: Ord>(&mut self, f: impl Fn(&T) -> K) {
+    self.as_mut_slice().sort_by_key(f)
   }
 }
 

--- a/kwap_common/src/lib.rs
+++ b/kwap_common/src/lib.rs
@@ -4,12 +4,11 @@
 #![cfg_attr(all(not(test), feature = "no_std"), no_std)]
 #![cfg_attr(not(test), forbid(missing_debug_implementations, unreachable_pub))]
 #![cfg_attr(not(test), deny(unsafe_code, missing_copy_implementations))]
-#![cfg_attr(any(docsrs, feature = "docs"), feature(doc_cfg))]
 #![deny(missing_docs)]
 
 extern crate alloc;
 use alloc::vec::Vec;
-use core::ops::{Index, IndexMut};
+use core::ops::{DerefMut, Deref};
 
 /// An ordered collection of some type `T`.
 ///
@@ -25,34 +24,26 @@ use core::ops::{Index, IndexMut};
 /// possibility of memory defects and UB.
 ///
 /// # Requirements
-/// - `Default` for creating the collection
-/// - `Extend` for mutating and adding onto the collection (1 or more elements)
-/// - `Reserve` for reserving space ahead of time
-/// - `GetSize` for bound checks, empty checks, and accessing the length
-/// - `FromIterator` for collecting into the collection
-/// - `IntoIterator` for:
-///    - iterating and destroying the collection
-///    - for iterating over references to items in the collection
-///
-/// # Stupid `where` clause
-/// `where for<'a> &'a Self: IntoIterator<Item = &'a T>` is necessary to fold in the idea
-/// of "A reference (of any arbitrary lifetime `'a`) to an Array must support iterating over references (`'a`) of its elements."
-///
-/// A side-effect of this where clause is that because it's not a trait bound, it must be propagated to every bound that requires an `Array`.
-///
-/// Less than ideal, but far preferable to coupling tightly to a particular collection and maintaining separate `alloc` and non-`alloc` implementations.
+/// - [`Default`] for creating the collection
+/// - [`Extend`] for mutating and adding onto the collection (1 or more elements)
+/// - [`Reserve`] for reserving space ahead of time
+/// - [`Insert`] for pushing and inserting elements into the collection
+/// - [`Deref<Target = [T]>`](Deref) and [`DerefMut`] for:
+///    - indexing ([`Index`](core::ops::Index), [`IndexMut`](core::ops::IndexMut))
+///    - iterating ([`&[T].iter()`](primitive@slice#method.iter) and [`&mut [T].iter_mut()`](primitive@slice#method.iter_mut))
+/// - [`GetSize`] for bound checks, empty checks, and accessing the length
+/// - [`FromIterator`] for [`collect`](core::iter::Iterator#method.collect)ing into the collection
+/// - [`IntoIterator`] for iterating and destroying the collection
 pub trait Array<T>:
   Default
   + Insert<T>
-  + Index<usize, Output = T>
-  + IndexMut<usize>
   + GetSize
   + Reserve
-  + SortByKey<T>
+  + Deref<Target = [T]>
+  + DerefMut
   + Extend<T>
   + FromIterator<T>
   + IntoIterator<Item = T>
-  where for<'a> &'a Self: IntoIterator<Item = &'a T>
 {
 }
 


### PR DESCRIPTION
This removes the propagating `where for<'a> &'a Self: IntoIterator<&'a T>` bound, `Index` and `IndexMut` bounds.

These have been totally replaced by `Deref<Target = [T]>` and `DerefMut` bounds, meaning that an "`Array`" must be coercible to a slice. This is a little more restrictive but **drastically** reduces code footprint and type complexity.